### PR TITLE
[IMP] track access rights change

### DIFF
--- a/__manifest__.py
+++ b/__manifest__.py
@@ -21,6 +21,7 @@
         'views/res_users.xml',
         'views/account_bank_statement.xml',
         'views/account_move.xml',
+        'views/check_access.xml',
         'views/sale_order.xml',
         'views/stock_picking.xml',
         'views/project_task.xml',

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from . import users
+from . import account_journal
 from . import account_move
 from . import stock_location
+from . import stock_warehouse

--- a/models/account_journal.py
+++ b/models/account_journal.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+
+from odoo import models, fields
+
+
+class AccountJournal(models.Model):
+    _inherit = "account.journal"
+
+    sbu_allowed_user_ids = fields.Many2many('res.users', string="Allowed Users")

--- a/models/stock_warehouse.py
+++ b/models/stock_warehouse.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+
+from odoo import models, fields
+
+
+class StockWarehouse(models.Model):
+    _inherit = "stock.warehouse"
+
+    sbu_allowed_user_ids = fields.Many2many('res.users', string="Allowed Users")

--- a/models/users.py
+++ b/models/users.py
@@ -4,27 +4,59 @@ from odoo import models, fields
 
 
 class Users(models.Model):
-    
-    _inherit = 'res.users'
+    _name = 'res.users'
+    _inherit = [
+        'res.users',
+        'mail.thread',  # add chatter capability
+    ]
 
     sbu_allowed_users_ids = fields.Many2many(
-        comodel_name='res.users', 
-        relation="sbu_allowed_users_rel", 
-        column1="left_user_id", 
-        column2="right_user_id", 
-        string="Allowed Users", 
+        comodel_name='res.users',
+        relation="sbu_allowed_users_rel",
+        column1="left_user_id",
+        column2="right_user_id",
+        string="Allowed Users",
         domain=['|', ('active', '=', True), ('active', '=', False)],
         context={'active_test': False},
     )
-    sbu_allowed_warehouses_ids = fields.Many2many(
-        comodel_name='stock.warehouse', 
-        relation="sbu_allowed_warehouses_rel", 
-        column1="res_user_id", 
-        column2="stock_warehouse_id", 
-        string="Allowed Warehouse", 
-        store=True,
+    sbu_allowed_user_ids_inverse = fields.Many2many(
+        comodel_name='res.users',
+        relation="sbu_allowed_users_rel",
+        column1="right_user_id",
+        column2="left_user_id",
+        string="Users Allowed",
     )
-    journal_ids = fields.Many2many(
-        'account.journal', 
-        string="Allowed Journals",
-    )
+    sbu_allowed_warehouses_ids = fields.Many2many('stock.warehouse', string="Allowed Warehouse")
+    journal_ids = fields.Many2many('account.journal', string="Allowed Journals")
+
+    def write(self, values):
+        autor = self.env.user.name
+        user_groups = {}
+        to_track = [
+            'groups_id',
+            'sbu_allowed_users_ids',
+            'sbu_allowed_warehouses_ids',
+            'journal_ids',
+        ]
+        for user in self:
+            user_groups[user] = {}
+            for field in to_track:
+                user_groups[user][field] = user[field]
+
+        res = super().write(values)
+
+        for user in self:
+            body = []
+            for field in to_track:
+                previous_values = user_groups[user][field]
+                new_values = user[field] - previous_values
+                removed_values = previous_values - user[field]
+                if new_values:
+                    body.append(f"- a ajouté l'accès à [{len(new_values)} {new_values._description}] : {new_values.mapped('display_name')}")
+                if removed_values:
+                    body.append(f"- a retiré l'accès à [{len(removed_values)} {removed_values._description}] : {removed_values.mapped('display_name')}")
+            if body:
+                body.insert(0, autor)
+                user.message_post(body='<br>'.join(body))
+
+        return res

--- a/views/check_access.xml
+++ b/views/check_access.xml
@@ -1,0 +1,117 @@
+<odoo>
+<data>
+    <!-- Warehouse -->
+    <record id="warehouse_access_tree" model="ir.ui.view">
+        <field name="name">warehouse.access.view.tree</field>
+        <field name="model">stock.warehouse</field>
+        <field name="arch" type="xml">
+            <tree string="Warehouse Access" delete="0" create="0">
+                <field name="name"/>
+                <field name="sbu_allowed_user_ids"/>
+            </tree>
+        </field>
+    </record>
+    <record id="warehouse_access_form" model="ir.ui.view">
+        <field name="name">warehouse.access.view.form</field>
+        <field name="model">stock.warehouse</field>
+        <field name="arch" type="xml">
+            <form string="Warehouse Access">
+                <field name="name"/>
+                <field name="sbu_allowed_user_ids"/>
+            </form>
+        </field>
+    </record>
+
+    <record id="warehouse_access_action" model="ir.actions.act_window">
+        <field name="name">Warehouse Access</field>
+        <field name="res_model">stock.warehouse</field>
+        <field name="view_mode">tree,form</field>
+        <field name="view_ids" eval="[(5, 0, 0),
+            (0, 0, {'view_mode': 'tree', 'view_id': ref('gse_access_rights.warehouse_access_tree')}),
+            (0, 0, {'view_mode': 'form', 'view_id': ref('gse_access_rights.warehouse_access_form')})]"/>
+    </record>
+
+    <menuitem
+        name="Warehouse Access"
+        id="warehouse_access_menu"
+        parent="base.menu_users"
+        action="warehouse_access_action"
+        sequence="106"/>
+
+    <!-- Users -->
+    <record id="user_access_tree" model="ir.ui.view">
+        <field name="name">user.access.view.tree</field>
+        <field name="model">res.users</field>
+        <field name="arch" type="xml">
+            <tree string="User Access" delete="0" create="0">
+                <field name="name"/>
+                <field name="sbu_allowed_user_ids_inverse"/>
+            </tree>
+        </field>
+    </record>
+    <record id="user_access_form" model="ir.ui.view">
+        <field name="name">user.access.view.form</field>
+        <field name="model">res.users</field>
+        <field name="arch" type="xml">
+            <form string="User Access">
+                <field name="name"/>
+                <field name="sbu_allowed_user_ids_inverse"/>
+            </form>
+        </field>
+    </record>
+
+    <record id="user_access_action" model="ir.actions.act_window">
+        <field name="name">User Access</field>
+        <field name="res_model">res.users</field>
+        <field name="view_mode">tree,form</field>
+        <field name="view_ids" eval="[(5, 0, 0),
+            (0, 0, {'view_mode': 'tree', 'view_id': ref('gse_access_rights.user_access_tree')}),
+            (0, 0, {'view_mode': 'form', 'view_id': ref('gse_access_rights.user_access_form')})]"/>
+    </record>
+
+    <menuitem
+        name="User Access"
+        id="user_access_menu"
+        parent="base.menu_users"
+        action="user_access_action"
+        sequence="101"/>
+
+    <!-- Journal -->
+    <record id="account_journal_access_tree" model="ir.ui.view">
+        <field name="name">account.journal.access.view.tree</field>
+        <field name="model">account.journal</field>
+        <field name="arch" type="xml">
+            <tree string="Journal Account Access" delete="0" create="0">
+                <field name="name"/>
+                <field name="sbu_allowed_user_ids"/>
+            </tree>
+        </field>
+    </record>
+    <record id="account_journal_access_form" model="ir.ui.view">
+        <field name="name">account.journal.access.view.form</field>
+        <field name="model">account.journal</field>
+        <field name="arch" type="xml">
+            <form string="Journal Account Access">
+                <field name="name"/>
+                <field name="sbu_allowed_user_ids"/>
+            </form>
+        </field>
+    </record>
+
+    <record id="account_journal_access_action" model="ir.actions.act_window">
+        <field name="name">Journal Account Access</field>
+        <field name="res_model">account.journal</field>
+        <field name="view_mode">tree,form</field>
+        <field name="view_ids" eval="[(5, 0, 0),
+            (0, 0, {'view_mode': 'tree', 'view_id': ref('gse_access_rights.account_journal_access_tree')}),
+            (0, 0, {'view_mode': 'form', 'view_id': ref('gse_access_rights.account_journal_access_form')})]"/>
+    </record>
+
+    <menuitem
+        name="Journal Account Access"
+        id="account_journal_access_menu"
+        parent="base.menu_users"
+        action="account_journal_access_action"
+        sequence="110"/>
+</data>
+</odoo>

--- a/views/res_users.xml
+++ b/views/res_users.xml
@@ -35,6 +35,13 @@
                         </group>
                     </page>
                 </xpath>
+                <form position="inside">
+                    <div class="oe_chatter">
+                        <field name="message_follower_ids"/>
+                        <field name="activity_ids"/>
+                        <field name="message_ids"/>
+                    </div>
+                </form>
             </data>
         </field>
     </record>

--- a/views/sale_order.xml
+++ b/views/sale_order.xml
@@ -30,17 +30,27 @@
                 <xpath expr="//field[@name='opportunity_id']" position="attributes">
                     <attribute name="groups"/>
                 </xpath>
-                <xpath expr="//button[@name='action_done']" position="attributes">
-                    <attribute name="groups">account_approval.group_sales_level_manager</attribute>
-                </xpath>
-                <xpath expr="//button[@name='action_unlock']" position="attributes">
-                    <attribute name="groups">account_approval.group_sales_level_manager</attribute>
-                </xpath>
                 <xpath expr="//button[@name='action_confirm'][1]" position="replace">
                     <button name="action_confirm" id="action_confirm" data-hotkey="v" string="Confirm" class="btn-primary" type="object" attrs="{'invisible': [('state', 'not in', ['sent'])]}" confirm="Une fois confirmée, le devis ne pourra plus être modifié. Assurez-vous que tous les produits sont bien présents sur le devis avant de confirmer."/>
                 </xpath>
                 <xpath expr="//button[@name='action_confirm'][2]" position="replace">
                     <button name="action_confirm" data-hotkey="v" string="Confirm" type="object" attrs="{'invisible': [('state', 'not in', ['draft'])]}" confirm="Une fois confirmée, le devis ne pourra plus être modifié. Assurez-vous que tous les produits sont bien présents sur le devis avant de confirmer."/>
+                </xpath>
+            </data>
+        </field>
+    </record>
+    <record id="sbu_sale_order_done" model="ir.ui.view">
+    <field name="name">sbu.sale.order.form.done</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_sales_order_auto_done_setting"/>
+        <field name="priority">20</field>
+        <field name="arch" type="xml">
+            <data>
+                <xpath expr="//button[@name='action_done']" position="attributes">
+                    <attribute name="groups">account_approval.group_sales_level_manager</attribute>
+                </xpath>
+                <xpath expr="//button[@name='action_unlock']" position="attributes">
+                    <attribute name="groups">account_approval.group_sales_level_manager</attribute>
                 </xpath>
             </data>
         </field>


### PR DESCRIPTION
Purpose:
a. Frequently users asks to add the access to a Journal, a warehouse,
   or a specific app.
   And as there are 3 people who can change the access rights, we need
   to have an historic of all changes.
b. With this module, we can add Journals, Users and Warehouses to an
   user.
   It's convenient to see on each user what are his access.
   But, what's missing is a view from the Journal, Users and Warehouses,
   who have access to it.
   And as we're having more and more users, it's important.

Specification:
a. Add a chatter on res.user form
   - track every changes (change of rule),
   - add users, warehouses or journal b. add menu: Settings > Users & Companies :
   - User Access
   - Warehouse Access
   - Journal Access

   On each view (view list), add the users, the warehouses, and the
   journals
   click on each, open a form view with a table with the users who have
   access to this users, the users who have access to the wh, etc.

Closes #2