### PR TITLE
[MIG] v16

### DIFF
--- a/__manifest__.py
+++ b/__manifest__.py
@@ -3,7 +3,11 @@
 {
     'name': "Access Rigths",
     'version': '0.8.2',
-    'depends': ['base', 'hr', 'l10n_be', 'account', 'account_accountant', 'sale', 'stock', 'partner_commission', 'industry_fsm', 'industry_fsm_sale_report'],
+    'depends': [
+        'base', 'hr', 'l10n_be', 'account', 'account_accountant', 'sale', 'stock', 'partner_commission', 'industry_fsm',
+        'industry_fsm_sale_report',
+        'account_approval',  # account_approval.group_sales_level_manager
+    ],
     'description': """
     Allow to specify access rights on users, journals and warehouses.
     """,

--- a/security/ir.model.access.csv
+++ b/security/ir.model.access.csv
@@ -9,7 +9,6 @@ access_account_move_line_uinvoice,account.move.line invoice,account.model_accoun
 access_account_analytic_line_invoice,account.analytic.line invoice,account.model_account_analytic_line,gse_access_rights.group_account_cashier,1,1,1,1
 access_account_journal_invoice,account.journal invoice,account.model_account_journal,gse_access_rights.group_account_cashier,1,0,0,0
 access_account_account_invoice,account.account invoice,account.model_account_account,gse_access_rights.group_account_cashier,1,0,0,0
-access_account_account_type_invoice,account.account.type invoice,account.model_account_account_type,gse_access_rights.group_account_cashier,1,0,0,0
 
 access_account_tax_invoice,account.tax,account.model_account_tax,gse_access_rights.group_account_cashier,1,0,0,0
 access_account_account_tax_user,account.account.tag,account.model_account_account_tag,gse_access_rights.group_account_cashier,1,0,0,0
@@ -27,5 +26,3 @@ access_account_payment,account.payment,account.model_account_payment,gse_access_
 access_account_payment_register,access.account.payment.register,account.model_account_payment_register,gse_access_rights.group_account_cashier,1,1,1,0
 access_account_move_reversal,access.account.move.reversal,account.model_account_move_reversal,gse_access_rights.group_account_cashier,1,1,1,0
 access_account_invoice_send,access.account.invoice.send,account.model_account_invoice_send,gse_access_rights.group_account_cashier,1,1,1,0
-
-access_account_analytic_default_invoice,account.analytic.default invoice,account.model_account_analytic_default,gse_access_rights.group_account_cashier,1,1,1,1

--- a/views/account_bank_statement.xml
+++ b/views/account_bank_statement.xml
@@ -2,15 +2,15 @@
 <odoo>
     <record id="sbu_account_view_bank_statement_form" model="ir.ui.view">
         <field name="name">sbu.account.view_bank_statement_form</field>
-        <field name="model">account.bank.statement</field>
-        <field name="inherit_id" ref="account.view_bank_statement_form"/>
+        <field name="model">bank.rec.widget</field>
+        <field name="inherit_id" ref="account_accountant.view_bank_rec_widget_form"/>
         <field name="priority">20</field>
         <field name="arch" type="xml">
             <data>
-                <xpath expr="//button[@name='action_bank_reconcile_bank_statements']" position="attributes">
+                <xpath expr="//button[@name='button_validate']" position="attributes">
                     <attribute name="groups">account.group_account_invoice</attribute>
                 </xpath>
-                <xpath expr="//button[@name='button_post']" position="attributes">
+                <!-- <xpath expr="//button[@name='button_post']" position="attributes">
                     <attribute name="groups">account.group_account_invoice</attribute>
                 </xpath>
                 <xpath expr="//button[@name='button_reopen']" position="attributes">
@@ -18,7 +18,7 @@
                 </xpath>
                 <xpath expr="//button[@name='button_reprocess']" position="attributes">
                     <attribute name="groups">account.group_account_invoice</attribute>
-                </xpath>
+                </xpath> -->
             </data>
         </field>
     </record>

--- a/views/account_move.xml
+++ b/views/account_move.xml
@@ -24,30 +24,39 @@
         <field name="name">goshop.invoice.payment.outstanding.form</field>
         <field name="model">account.move</field>
         <field name="inherit_id" ref="account.view_move_form"/>
-        <field name="groups_id" eval="[(4, ref('account.group_account_manager'))]"/>
         <field name="priority">999</field>
         <field name="arch" type="xml">
             <data>
                 <xpath expr="//field[@name='is_move_sent']" position="before">
-                    <field name="invoice_has_outstanding" invisible="1"/>
+                    <t groups="account.group_account_manager">
+                        <field name="invoice_has_outstanding" invisible="1"/>
+                    </t>
                 </xpath>
                 <xpath expr="//sheet" position="before">
-                    <div groups="account.group_account_invoice" class="alert alert-warning" role="alert" style="margin-bottom:0px;" attrs="{'invisible': ['|', ('state', '!=', 'draft'), ('tax_lock_date_message', '=', False)]}">
-                        <field name="tax_lock_date_message" nolabel="1"/>
-                    </div>
-                    <div groups="account.group_account_invoice" class="alert alert-info" role="alert" style="margin-bottom:0px;" attrs="{'invisible': ['|', '|', ('move_type', 'not in', ('in_invoice', 'in_refund')), ('invoice_has_outstanding', '=', False), ('payment_state', '!=', 'not_paid')]}">
-                        You have <bold><a class="alert-link" href="#outstanding" role="button">outstanding debits</a></bold> for this supplier. You can allocate them to mark this bill as paid.
-                    </div>
-                    <div groups="account.group_account_invoice" class="alert alert-info" role="alert" style="margin-bottom:0px;" attrs="{'invisible': ['|', ('move_type', 'not in', ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt')), ('invoice_has_matching_suspense_amount','=',False)]}">
-                        You have suspense account moves that match this invoice. <bold><button class="alert-link" type="object" name="action_open_matching_suspense_moves" role="button" string="Check them" style="padding: 0;vertical-align: baseline;"/></bold> to mark this invoice as paid.
-                    </div>
-                </xpath> 
+                    <t groups="account.group_account_manager">
+                        <div groups="account.group_account_invoice" class="alert alert-warning" role="alert" style="margin-bottom:0px;" attrs="{'invisible': ['|', ('state', '!=', 'draft'), ('tax_lock_date_message', '=', False)]}">
+                            <field name="tax_lock_date_message" nolabel="1"/>
+                        </div>
+                        <div groups="account.group_account_invoice" class="alert alert-info" role="alert" style="margin-bottom:0px;" attrs="{'invisible': ['|', '|', ('move_type', 'not in', ('in_invoice', 'in_refund')), ('invoice_has_outstanding', '=', False), ('payment_state', '!=', 'not_paid')]}">
+                            You have <bold><a class="alert-link" href="#outstanding" role="button">outstanding debits</a></bold> for this supplier. You can allocate them to mark this bill as paid.
+                        </div>
+                        <!-- <div groups="account.group_account_invoice" class="alert alert-info" role="alert" style="margin-bottom:0px;" attrs="{'invisible': ['|', ('move_type', 'not in', ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt')), ('invoice_has_matching_suspense_amount','=',False)]}">
+                            You have suspense account moves that match this invoice. <bold><button class="alert-link" type="object" name="action_open_matching_suspense_moves" role="button" string="Check them" style="padding: 0;vertical-align: baseline;"/></bold> to mark this invoice as paid.
+                        </div> -->
+                    </t>
+                </xpath>
                 <xpath expr="//field[@name='narration']" position="before">
-                    <field name="invoice_outstanding_credits_debits_widget" class="oe_invoice_outstanding_credits_debits" colspan="2" nolabel="1" widget="payment" attrs="{'invisible': ['|', ('state', '!=', 'posted'), ('move_type', 'in', ('out_receipt', 'in_receipt'))]}" groups="account.group_account_user"/>
+                    <t groups="account.group_account_manager">
+                        <field name="invoice_outstanding_credits_debits_widget" class="oe_invoice_outstanding_credits_debits" colspan="2" nolabel="1" widget="payment" attrs="{'invisible': ['|', ('state', '!=', 'posted'), ('move_type', 'in', ('out_receipt', 'in_receipt'))]}" groups="account.group_account_user"/>
+                    </t>
                 </xpath>
-                <xpath expr="//field[@name='amount_total']" position="after">
-                    <field name="invoice_payment_wigdet_journal" colspan="2" nolabel="1" widget="payment"/>
-                </xpath>
+                
+                <xpath expr="//field[@name='invoice_payments_widget']" position="after">
+                     <field name="invoice_payments_widget" invisible="1"/>
+                 </xpath>
+                 <xpath expr="//field[@name='invoice_payments_widget']" position="attributes">
+                     <attribute name="groups">account.group_account_manager</attribute>
+                 </xpath>
             </data>
         </field>
     </record>

--- a/views/project_task.xml
+++ b/views/project_task.xml
@@ -25,4 +25,21 @@
             </data>
         </field>
     </record>
+
+    <menuitem id="industry_fsm.fsm_menu_planning"
+        parent="industry_fsm.fsm_menu_root"
+        groups="gse_access_rights.group_fsm_planner"/>
+
+    <menuitem id="industry_fsm.project_task_menu_planning_by_user_fsm"
+        parent="industry_fsm.fsm_menu_planning"
+        groups="gse_access_rights.group_fsm_planner"/>
+
+    <menuitem id="industry_fsm.project_task_menu_planning_by_project_fsm"
+        parent="industry_fsm.fsm_menu_planning"
+        groups="gse_access_rights.group_fsm_planner"/>
+
+    <menuitem id="industry_fsm_report.project_task_menu_planning_by_project_fsm"
+        parent="industry_fsm.fsm_menu_planning"
+        groups="gse_access_rights.group_fsm_planner"/>
+
 </odoo>

--- a/views/sale_order.xml
+++ b/views/sale_order.xml
@@ -7,14 +7,19 @@
         <field name="priority">20</field>
         <field name="arch" type="xml">
             <data>
+                <!-- we are adding groups to field but this field is also used
+                in invisible condition of other field so we need it -->
+                <xpath expr="//field[@name='referrer_id']" position="after">
+                    <field name="referrer_id" invisible="1"/>
+                </xpath>
                 <xpath expr="//field[@name='referrer_id']" position="attributes">
                     <attribute name="groups">partner_commission.group_commission_manager</attribute>
                     <attribute name="options">{"no_open":true}</attribute>
                 </xpath>
-                <xpath expr="//field[@name='commission_plan_id']" position="attributes">
-                    <attribute name="groups">partner_commission.group_commission_manager</attribute>
+                <xpath expr="//field[@name='commission_plan_id']" position="after">
+                    <field name="commission_plan_id" invisible="1"/>
                 </xpath>
-                <xpath expr="//field[@name='commission']" position="attributes">
+                <xpath expr="//field[@name='commission_plan_id']" position="attributes">
                     <attribute name="groups">partner_commission.group_commission_manager</attribute>
                 </xpath>
             </data>


### PR DESCRIPTION
…://github.com/odoo/upgrade/blame/master/migrations/account/16.0.1.2/pre-migrate.py#L237

- Plus possible de faire <field name="groups_id" eval="[(4, ref('account.group_account_manager'))]"/> sur une vue héritée, il faut adapter tous les xpath à l'intérieur, cf https://github.com/odoo/upgrade/commit/b4375ad4c932e0f7938f5b6e7034edde2bc92ce4#diff-2e0dbcae3e1794f7c41dfbd02c6daea5f7c88277aad8d9fce7c602602cce7bfaR235
- Plus possible d'ajouter un groups à un field via xpath (comme tes modules font pour ajouter ton group custom à un field dans une vue odoo) si celui ci est utilisé ailleurs dans un invisible=(condition sur field) car maintenant groups sur un field le retire du DOM/de la vue si tu n'as pas le groupe, donc la computation de invisible qui dépend de lui ne peut pas se faire pour ceux qui n'ont pas le groupe, cf https://github.com/odoo/odoo/commit/0501bbd62e517f6c215d9e7e36d61747c7f5816b