### PR TITLE
[FIX] prevent compute sudo access rule error

### DIFF
--- a/models/__init__.py
+++ b/models/__init__.py
@@ -3,5 +3,6 @@
 from . import users
 from . import account_journal
 from . import account_move
+from . import account_payment_register
 from . import stock_location
 from . import stock_warehouse

--- a/models/account_payment_register.py
+++ b/models/account_payment_register.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+
+from odoo import api, models
+
+
+class AccountPaymentRegister(models.TransientModel):
+    _inherit = 'account.payment.register'
+
+    @api.model
+    def _get_batch_available_journals(self, batch_result):
+        return super(
+            AccountPaymentRegister, self.with_user(self.env.user),
+        )._get_batch_available_journals(batch_result)


### PR DESCRIPTION
`Access to Journal SBU` ir.rule is failing because `payment_method_line_id` is a stored compute (so `compute_sudo=True` by defaut.
It ends up calling `_get_batch_available_journals` which does a `search()` on journals and bypass the `ir.rule` temporarily until the code return in "non sudo" mode and crash.